### PR TITLE
Fix getPlaces by separating parse function for regular items and popular items

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 An API Wrapper for Atlas Obscura
 
+## Installation
+```
+npm install --save node-atlas-obscura
+```
+
 ## Usage
 
 ```js
-const Atlas = require('node-atlas-obscura')
-const atlas = new Atlas()
+const Atlas = require('node-atlas-obscura');
+const atlas = new Atlas();
 ```
 
 ### Get places in a city
@@ -14,8 +19,8 @@ const atlas = new Atlas()
 ```js
 atlas.getPlaces({
     city: 'Berlin',
-    country: 'Germany'
-    orderByRecent = false
+    country: 'Germany',
+    orderByRecent: false
 })
 /*
 If true, this method will show most recent places added for this location

--- a/lib/atlas-obscura.js
+++ b/lib/atlas-obscura.js
@@ -3,6 +3,7 @@ const slugify = require('@sindresorhus/slugify');
 
 const {
   parseItems,
+  parsePopularItems,
   parseTags,
   getPaginationNextLink,
   parsePhotos,
@@ -25,7 +26,7 @@ class AtlasObscura {
           sort: 'likes_count'
         }
       });
-      return await parseItems(response.data);
+      return await parsePopularItems(response.data);
     } catch (err) {
       console.log(err);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,38 @@ function parseItems(body) {
   const $ = cheerio.load(body);
 
   return new Promise((resolve, reject) => {
+    $('.--content-card-item').each((i, element) => {
+      const place = {
+        id: $(element)
+          .data('item-id'),
+        title: $(element)
+          .find('.--content-card-v2-title')
+          .text().replace(/(\r\n|\n|\r)/gm, ""),
+        location: $(element)
+          .find('.--place')
+          .text(),
+        description: $(element)
+          .find('.Card__content')
+          .text().replace(/(\r\n|\n|\r)/gm, ""),
+        url:
+          'http://www.atlasobscura.com' +
+          $(element)
+            .attr('href'),
+        img: $(element)
+          .find('.Card__img')
+          .data('src'),
+      };
+      items.push(place);
+    });
+    resolve(items);
+  });
+}
+
+function parsePopularItems(body) {
+  const items = [];
+  const $ = cheerio.load(body);
+
+  return new Promise((resolve, reject) => {
     $('.content-card-text').each((i, element) => {
       const place = {
         id: $(element)
@@ -105,6 +137,7 @@ function parseText(body) {
 
 module.exports = {
   parseItems,
+  parsePopularItems,
   parseTags,
   parsePhotos,
   parseText,


### PR DESCRIPTION
Hi, thanks for the work on this library, it was really useful for a pet project. I wanted to update the parsing of items given that the classes of the page changed and "getPlaces" method no longer works.

Here I just updated jquery selectors and separated the method to parse regular items and popular items.

Let me know if I could improve somehow :)